### PR TITLE
Remove extra traling comma in support hash

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -11,7 +11,7 @@
     },
     "support": {
         "email": "rob AT-SIGN hoelz.ro",
-        "bugtracker": "https://github.com/hoelzro/p6-priorityqueue/issues",
+        "bugtracker": "https://github.com/hoelzro/p6-priorityqueue/issues"
     },
     "license": "http://opensource.org/licenses/MIT",
     "tags": [


### PR DESCRIPTION
The trailing comma after the `bugtracker` item in the `support` hash makes
the file invalid JSON.  This change corrects the issue.
