### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -18,7 +18,7 @@ plan 3;
         }
     };
 
-    is_deeply @enqueued, @sorted;
+    is-deeply @enqueued, @sorted;
 }
 
 {
@@ -32,7 +32,7 @@ plan 3;
         }
     };
 
-    is_deeply @enqueued, @sorted;
+    is-deeply @enqueued, @sorted;
 }
 
 {
@@ -50,5 +50,5 @@ plan 3;
         }
     };
 
-    is_deeply @enqueued, @sorted;
+    is-deeply @enqueued, @sorted;
 }


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants.  The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.
