### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -13,7 +13,7 @@
         "email": "rob AT-SIGN hoelz.ro",
         "bugtracker": "https://github.com/hoelzro/p6-priorityqueue/issues"
     },
-    "license": "http://opensource.org/licenses/MIT",
+    "license": "MIT",
     "tags": [
         "data structure"
     ]


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license